### PR TITLE
moving deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "benchmarks": "node benchmark"
   },
   "dependencies": {
-    "benchmarked": "^0.1.3",
-    "chalk": "^0.5.1",
-    "micromatch": "^1.2.2",
     "to-key": "^1.0.0"
   },
   "devDependencies": {
+    "micromatch": "^1.2.2",
+    "chalk": "^0.5.1",
+    "benchmarked": "^0.1.3",
     "mocha": "^2.1.0",
     "should": "*"
   },


### PR DESCRIPTION
A patch to remove benchmarked and other unnecessary development (test) dependencies from npm install. This was branched off of the 0.3.0 tag, and isn't intended to merge directly with master. 

You could do something like this:

``` sh
# fetch this PR
git fetch origin pull/3/head:fix-dev-dep

# check it out locally
git checkout fix-dev-dep

# apply hot-fix (creates a tag)
npm version 0.3.1

# publish hot-fix
npm publish

# push tags and optionally this branch to remote
git push --tags && git push origin fix-dev-dep
```

Or you could just change the package.json manually if you don't want to pollute git history with this. 
