### PR TITLE
pass the given string to the function, even if it's empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function regexCache(fn, str, opts) {
     if (typeof fn !== 'function') {
       return fn;
     }
-    return basic[key] || (basic[key] = fn());
+    return basic[key] || (basic[key] = fn(str));
   }
 
   var isString = typeof str === 'string';


### PR DESCRIPTION
Currently, calling `micromatch.makeRe('')` results in `TypeError: micromatch.expand(): argument should be a string.`, because the empty string is getting lost here.
